### PR TITLE
Feature: Hide residential units within real estate lists

### DIFF
--- a/src/Resources/contao/classes/Project.php
+++ b/src/Resources/contao/classes/Project.php
@@ -38,9 +38,10 @@ class Project
      * @param $arrOptions
      * @param $mode
      * @param $addFragments
+     * @param $objModule
      * @param $context
      */
-    public function setFilterParameter(&$arrColumns, &$arrValues, &$arrOptions, $mode, $addFragments, $context): void
+    public function setFilterParameter(&$arrColumns, &$arrValues, &$arrOptions, $mode, $addFragments, $objModule, $context): void
     {
         $t = static::$strTable;
 

--- a/src/Resources/contao/classes/Project.php
+++ b/src/Resources/contao/classes/Project.php
@@ -49,6 +49,11 @@ class Project
         {
             $arrColumns[] = "$t.master=''";
         }
+
+        if ('hideUnits' === $mode)
+        {
+            $arrColumns[] = "$t.gruppenKennung=''";
+        }
     }
 
     /**

--- a/src/Resources/contao/classes/Project.php
+++ b/src/Resources/contao/classes/Project.php
@@ -101,7 +101,7 @@ class Project
      *
      * @return int: marketing status in percent
      */
-    public static function getProjectMarketingStatus($objMaster): int
+    public static function getProjectMarketingStatus($objMaster)
     {
         $t = static::$strTable;
 
@@ -243,7 +243,7 @@ class Project
      *
      * @param $realEstate
      */
-    public static function getNumberOfChildren($realEstate): int
+    public static function getNumberOfChildren($realEstate)
     {
         // If we have received a master property and the number of units has been transferred, return it directly
         if ((bool) $realEstate->master && $realEstate->anzahlWohneinheiten)

--- a/src/Resources/contao/dca/tl_module.php
+++ b/src/Resources/contao/dca/tl_module.php
@@ -22,6 +22,9 @@ if (AddonManager::valid())
     // Extend estate manager statusTokens field options
     $GLOBALS['TL_DCA']['tl_module']['fields']['statusTokens']['options'][] = 'project';
 
+    // Extend estate manager filterMode field options
+    $GLOBALS['TL_DCA']['tl_module']['fields']['filterMode']['options'][] = 'hideUnits';
+
     // Add module palette for projects
     $GLOBALS['TL_DCA']['tl_module']['palettes']['realEstateProjectList'] = '{title_legend},name,headline,type;{config_legend},realEstateGroups,numberOfItems,perPage,filterMode,childrenObserveFiltering,addSorting;{redirect_legend},jumpTo,jumpToProject;{item_extension_legend:hide},addProvider,addContactPerson;{template_legend:hide},statusTokens,customTpl,realEstateProjectTemplate,realEstateTemplate,realEstateProviderTemplate,realEstateContactPersonTemplate;{image_legend:hide},imgSize,projectImgSize,providerImgSize,contactPersonImgSize;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID';
 

--- a/src/Resources/contao/languages/de/tl_real_estate_misc.xlf
+++ b/src/Resources/contao/languages/de/tl_real_estate_misc.xlf
@@ -48,6 +48,11 @@
         <source>No projects are currently under construction.</source>
         <target>Derzeit befinden sich keine Projekte im Bau.</target>
       </trans-unit>
+
+      <trans-unit id="tl_real_estate_misc.hideUnits">
+        <source>Hide residential units</source>
+        <target>Wohneinheiten ausblenden</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Resources/contao/languages/en/tl_real_estate_misc.xlf
+++ b/src/Resources/contao/languages/en/tl_real_estate_misc.xlf
@@ -37,6 +37,10 @@
       <trans-unit id="tl_real_estate_project_misc.noProjectResults">
         <source>No projects are currently under construction.</source>
       </trans-unit>
+
+      <trans-unit id="tl_real_estate_misc.hideUnits">
+        <source>Hide residential units</source>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Resources/contao/modules/ModuleRealEstateProjectList.php
+++ b/src/Resources/contao/modules/ModuleRealEstateProjectList.php
@@ -144,7 +144,7 @@ class ModuleRealEstateProjectList extends ModuleRealEstate
             if ((bool) $this->childrenObserveFiltering)
             {
                 $arrNumberOfChildren = [];
-                $objNumberOfChildren = $this->Database->execute("SELECT COUNT(id) as cnt, gruppenKennung FROM $this->strTable WHERE gruppenKennung IN(".implode(',', $projectIds).") AND master='' GROUP BY gruppenKennung");
+                $objNumberOfChildren = $this->Database->execute("SELECT COUNT(id) as cnt, gruppenKennung FROM $this->strTable WHERE gruppenKennung IN(".$queryProjects.") AND master='' GROUP BY gruppenKennung");
 
                 while ($objNumberOfChildren->next())
                 {

--- a/src/Resources/contao/modules/ModuleRealEstateProjectList.php
+++ b/src/Resources/contao/modules/ModuleRealEstateProjectList.php
@@ -56,13 +56,6 @@ class ModuleRealEstateProjectList extends ModuleRealEstate
     protected $strTemplate = 'mod_realEstateProjectList';
 
     /**
-     * Template.
-     *
-     * @var string
-     */
-    protected $strProjectTemplate = 'real_estate_project_default';
-
-    /**
      * Do not display the module if there are no real estates.
      *
      * @return string
@@ -106,6 +99,8 @@ class ModuleRealEstateProjectList extends ModuleRealEstate
      */
     protected function compile(): void
     {
+        $strProjectTemplate = $this->realEstateProjectTemplate ?: 'real_estate_project_default';
+
         $this->addSorting();
 
         [$arrColumns, $arrValues, $arrOptions] = $this->getProjectParameters();
@@ -171,7 +166,7 @@ class ModuleRealEstateProjectList extends ModuleRealEstate
             while ($objProjects->next())
             {
                 $realEstate = new RealEstateModulePreparation($objProjects->current(), $this, null);
-                $objTemplate = new FrontendTemplate($this->strProjectTemplate);
+                $objTemplate = new FrontendTemplate($strProjectTemplate);
 
                 $objTemplate->realEstate = $realEstate;
                 $objTemplate->children = $arrProjects[$objProjects->master]['children'] ?: [];

--- a/src/Resources/contao/modules/ModuleRealEstateProjectList.php
+++ b/src/Resources/contao/modules/ModuleRealEstateProjectList.php
@@ -138,7 +138,9 @@ class ModuleRealEstateProjectList extends ModuleRealEstate
         {
             [$arrColumns, $arrValues, $arrOptions] = $this->objFilterSession->getParameter($this->realEstateGroups, $this->filterMode, (bool) $this->childrenObserveFiltering);
 
-            $arrColumns[] = "$this->strTable.gruppenKennung IN(".implode(',', $projectIds).')';
+            $queryProjects =  "'".implode("','", $projectIds)."'";
+
+            $arrColumns[] = "$this->strTable.gruppenKennung IN(".$queryProjects.')';
             $arrColumns[] = "$this->strTable.master=''";
 
             $objChildren = RealEstateModel::findPublishedBy($arrColumns, $arrValues, $arrOptions);

--- a/src/Resources/contao/modules/ModuleRealEstateProjectList.php
+++ b/src/Resources/contao/modules/ModuleRealEstateProjectList.php
@@ -163,13 +163,22 @@ class ModuleRealEstateProjectList extends ModuleRealEstate
 
             $objProjects->reset();
 
-            while ($objProjects->next())
+            if (isset($GLOBALS['TL_HOOKS']['compileRealEstateProject']) && \is_array($GLOBALS['TL_HOOKS']['compileRealEstateProject']))
             {
-                $realEstate = new RealEstateModulePreparation($objProjects->current(), $this, null);
+                foreach ($GLOBALS['TL_HOOKS']['compileRealEstateProject'] as $callback)
+                {
+                    $this->import($callback[0]);
+                    $this->{$callback[0]}->{$callback[1]}($objProjects, $arrProjects, $this);
+                }
+            }
+
+            foreach ($objProjects as $objProject)
+            {
+                $realEstate  = new RealEstateModulePreparation($objProject, $this,null);
                 $objTemplate = new FrontendTemplate($strProjectTemplate);
 
                 $objTemplate->realEstate = $realEstate;
-                $objTemplate->children = $arrProjects[$objProjects->master]['children'] ?: [];
+                $objTemplate->children = $arrProjects[$objProject->master]['children'] ?: [];
                 $objTemplate->jumpTo = $this->jumpToProject;
                 $objTemplate->imgSize = $this->projectImgSize;
                 $objTemplate->details = Project::getProjectSpecificDetails($realEstate);
@@ -184,11 +193,11 @@ class ModuleRealEstateProjectList extends ModuleRealEstate
                 }
                 elseif ((bool) $this->childrenObserveFiltering)
                 {
-                    $objTemplate->numberOfChildren = $arrNumberOfChildren[$objProjects->master];
+                    $objTemplate->numberOfChildren = $arrNumberOfChildren[$objProject->master];
                 }
                 else
                 {
-                    $objTemplate->numberOfChildren = \count($arrProjects[$objProjects->master]['children']);
+                    $objTemplate->numberOfChildren = \count($arrProjects[$objProject->master]['children']);
                 }
 
                 // add provider


### PR DESCRIPTION
<h3>Addition</h3>

- This PR includes an option to hide residential units within real estate lists (Hide residential units) https://github.com/contao-estatemanager/project/commit/46073dbcd220f63c0c621f790df80c3e7330f7d7

<h3>Bugfixes</h3>

- fixed a bug with getProjectMarketingStatus and getNumberOfChildren return types (returns float, not int) https://github.com/contao-estatemanager/project/commit/80d2ba267a74f230b977499caec069e67162b4f2
- fixed a bug where having multiple projects and using strings within group identifiers would break the query https://github.com/contao-estatemanager/project/pull/17/commits/5f903db6ba1f04bceff6bab0a2038d497b1b592b
- fixed a bug where the project child template could not be customized https://github.com/contao-estatemanager/project/pull/17/commits/7b9b872cdc2d58ef2a96e36f525221e3fe1755fd

